### PR TITLE
add range check to sort algorithms

### DIFF
--- a/book/src/arrays/sorted.md
+++ b/book/src/arrays/sorted.md
@@ -5,25 +5,40 @@ template IsSorted(n, b) {
   signal input in[n];
   signal output out;
 
+  // range check
+  for (var i = 0; i < n; i++) {
+    _ <== Num2Bits(b)(in[i]);
+  }
+
+  // accumulator for in[i-1] < in[1] checks
   var acc = 0;
   for (var i = 1; i < n; i++) {
     var isLessThan = LessEqThan(b)([in[i-1], in[i]]);
     acc += isLessThan;
   }
 
+  // note that technically it is possible for `acc` to overflow
+  // and wrap back to 0, however, that is unlikely to happen given
+  // how large the prime-field is and we would need that many components
+  // to be able to overflow
   signal outs <== acc;
   var outsIsZero = IsZero()(outs);
   out <== 1 - outsIsZero;
 }
 ```
 
-If we need an array to be sorted, we could instead sort the array out-of-circuit and pass in the sorted array, finally asserting that it is sorted indeed. To do this, we can simply check that consecutive elements are ordered, that is $a_{i-1} \leq a_{i}$ for all $1 \leq i \lt n$.
+If we need an array to be sorted, we could instead sort the array out-of-circuit and pass in the sorted array, finally asserting that it is sorted indeed. To do this, we can simply check that consecutive elements are ordered, that is $a_{i-1} \leq a_{i}$ for all $1 \leq i \lt n$. Since the correctness of `LessEqThan(b)` is guaranteed only for inputs of at most `b` bits, we also add a range check using `Num2Bits(b)`, which internally asserts that the input fits within `b` bits
 
 # `AssertSorted`
 
 ```cs
 template AssertSorted(n, b) {
   signal input in[n];
+
+  // range check
+  for (var i = 0; i < n; i++) {
+    _ <== Num2Bits(b)(in[i]);
+  }
 
   // accumulator for in[i-1] < in[1] checks
   var acc = 0;

--- a/circuits/arrays/sorted.circom
+++ b/circuits/arrays/sorted.circom
@@ -17,6 +17,11 @@ template IsSorted(n, b) {
   signal input in[n];
   signal output out;
 
+  // range check
+  for (var i = 0; i < n; i++) {
+    _ <== Num2Bits(b)(in[i]);
+  }
+
   // accumulator for in[i-1] < in[1] checks
   var acc = 0;
   for (var i = 1; i < n; i++) {
@@ -43,6 +48,11 @@ template IsSorted(n, b) {
 // - in: an array of `n` `b`-bit values
 template AssertSorted(n, b) {
   signal input in[n];
+
+  // range check
+  for (var i = 0; i < n; i++) {
+    _ <== Num2Bits(b)(in[i]);
+  }
 
   // accumulator for in[i-1] < in[1] checks
   var acc = 0;


### PR DESCRIPTION
Close #12 

Add rigorous range checks with `Num2Bits` to prevent the under-constrained problem due to insecure call of `LessThan` in `IsSorted` and `ArraySorted`.